### PR TITLE
Updates for TBC

### DIFF
--- a/Auctionator.lua
+++ b/Auctionator.lua
@@ -4487,9 +4487,9 @@ function Atr_Duration_Initialize(self)
 
 	-- DaMaGepy fix
   --Atr_Dropdown_AddPick (self, AUCTION_DURATION_ONE, 1, Atr_Duration_OnClick);
-  Atr_Dropdown_AddPick (self, "2 Hours", 1, Atr_Duration_OnClick);
-  Atr_Dropdown_AddPick (self, "8 Hours", 2, Atr_Duration_OnClick);
-  Atr_Dropdown_AddPick (self, "24 Hours", 3, Atr_Duration_OnClick);
+  Atr_Dropdown_AddPick (self, "12 Hours", 1, Atr_Duration_OnClick);
+  Atr_Dropdown_AddPick (self, "24 Hours", 2, Atr_Duration_OnClick);
+  Atr_Dropdown_AddPick (self, "48 Hours", 3, Atr_Duration_OnClick);
 
 end
 

--- a/Auctionator.toc
+++ b/Auctionator.toc
@@ -1,7 +1,7 @@
-## Interface: 11305
-## Title: Auctionator |cff00aa00Classicfix
-## Version: 100.0.10
-## Author: Borjamacare, Zirco, DaMaGepy, 1010101110
+## Interface: 20501
+## Title: Auctionator |cff00aa00BurningCrusadeClassicfix
+## Version: 100.0.11
+## Author: Borjamacare, Zirco, DaMaGepy, 1010101110, Hotrian
 ## X-Website: https://www.curseforge.com/wow/addons/auctionator-classicfix
 ## X-Localizations: enUS, itIT, deDE, ruRU, svSE, frFR, esES, zhTW
 ## Notes: A lightweight addon that makes it easy and fast to buy, sell and manage auctions

--- a/AuctionatorConfig.xml
+++ b/AuctionatorConfig.xml
@@ -67,7 +67,7 @@
   </Frame>
 
   <!-- Template for auctionator options panels -->
-  <Frame name="Atr_OptionsPanelTemplate" virtual="true">
+  <Frame name="Atr_OptionsPanelTemplate" virtual="true" inherits="BackdropTemplate">
     <Backdrop bgFile="Interface\CharacterFrame\UI-Party-Background" tile="true">
       <BackgroundInsets>
         <AbsInset bottom="5" left="5" right="5" top="5"/>
@@ -76,6 +76,16 @@
         <AbsValue val="32"/>
       </TileSize>
     </Backdrop>
+    <Scripts>
+      <OnShow>
+        self:SetBackdrop({
+          bgFile = "Interface\\CharacterFrame\\UI-Party-Background", 
+          tile = true,
+          tileSize = 32,
+          insets = { left = 5, right = 5, top = 5, bottom = 5, },
+        })
+      </OnShow>
+    </Scripts>
     <Layers>
       <Layer level="BACKGROUND">
         <FontString inherits="GameFontNormalLarge" name="$parent_ATitle">
@@ -116,8 +126,16 @@
       </TileSize>
     </Backdrop>
     <Scripts>
-      <OnLoad>self:SetBackdropColor(0.2, 0.2, 0.2);
+      <OnLoad>
+        self:SetBackdropColor(0.2, 0.2, 0.2);
       </OnLoad>
+      <OnShow>
+        self:SetBackdrop({
+          bgFile = "Interface\\Tooltips\\UI-Tooltip-Background", 
+          tile = true,
+          tileSize = 16,
+        })
+      </OnShow>
     </Scripts>
   </Frame>
   <!-- The Basic Options panel -->
@@ -640,7 +658,7 @@
           </OnVerticalScroll>
         </Scripts>
       </ScrollFrame>
-      <Frame name="Atr_Stacking_List">
+      <Frame name="Atr_Stacking_List" inherits="BackdropTemplate">
         <Size>
           <AbsDimension y="240"/>
         </Size>
@@ -661,6 +679,14 @@
             <AbsValue val="16"/>
           </EdgeSize>
         </Backdrop>
+        <Scripts>
+          <OnShow>
+            self:SetBackdrop({
+              edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border", 
+              edgeSize = 16,
+            })
+          </OnShow>
+        </Scripts>
       </Frame>
       <Button inherits="Atr_SmallButtonTemplate" name="$parent_Edit" parent="Atr_StackingOptionsFrame" text="EDIT">
         <Size>
@@ -694,7 +720,7 @@
       </Button>
     </Frames>
   </Frame>
-  <Button hidden="true" name="Atr_StackingEntryTemplate" virtual="true">
+  <Button hidden="true" name="Atr_StackingEntryTemplate" virtual="true" inherits="BackdropTemplate">
     <Size>
       <AbsDimension y="16"/>
     </Size>
@@ -779,6 +805,18 @@
         <AbsValue val="32"/>
       </EdgeSize>
     </Backdrop>
+    <Scripts>
+      <OnShow>
+        self:SetBackdrop({
+          bgFile = "Interface\\CharacterFrame\\UI-Party-Background", 
+          edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border", 
+          tile = true,
+          tileSize = 32,
+          edgeSize = 32,
+          insets = { left = 11, right = 12, top = 12, bottom = 11, },
+        })
+      </OnShow>
+    </Scripts>
     <Layers>
       <Layer level="BACKGROUND">
         <FontString inherits="GameFontNormalSmall" justifyH="LEFT" name="Atr_Mem_itemName_text" text="AUCTIONATOR_ITEM_NAME">
@@ -1115,6 +1153,18 @@
         <AbsValue val="32"/>
       </EdgeSize>
     </Backdrop>
+    <Scripts>
+      <OnShow>
+        self:SetBackdrop({
+          bgFile = "Interface\\CharacterFrame\\UI-Party-Background", 
+          edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border", 
+          tile = true,
+          tileSize = 32,
+          edgeSize = 32,
+          insets = { left = 11, right = 12, top = 12, bottom = 11, },
+        })
+      </OnShow>
+    </Scripts>
     <Layers>
       <Layer level="BACKGROUND">
         <FontString inherits="GameFontNormal" name="Atr_ClearConfirm_Text1" text="AUCTIONATOR_ARE_YOU_SURE">
@@ -1201,7 +1251,7 @@
           </OnVerticalScroll>
         </Scripts>
       </ScrollFrame>
-      <Frame name="Atr_ShpList_Frame">
+      <Frame name="Atr_ShpList_Frame" inherits="BackdropTemplate">
         <Anchors>
           <Anchor point="TOPLEFT" relativePoint="TOPLEFT" relativeTo="Atr_ShpList_ScrollFrame">
             <Offset x="-5" y="5"/>
@@ -1215,6 +1265,14 @@
             <AbsValue val="16"/>
           </EdgeSize>
         </Backdrop>
+        <Scripts>
+          <OnShow>
+            self:SetBackdrop({
+              edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border", 
+              edgeSize = 16,
+            })
+          </OnShow>
+        </Scripts>
       </Frame>
       <Button inherits="UIPanelButtonTemplate" name="Atr_ShpList_DeleteButton" text="Delete">
         <Size x="100" y="22"/>
@@ -1343,6 +1401,18 @@
         <AbsValue val="32"/>
       </EdgeSize>
     </Backdrop>
+    <Scripts>
+      <OnShow>
+        self:SetBackdrop({
+          bgFile = "Interface\\MERCHANTFRAME\\UI-BuyBack-TopLeft", 
+          edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border", 
+          tile = true,
+          tileSize = 256,
+          edgeSize = 32,
+          insets = { left = 2, right = 0, top = 2, bottom = 2, },
+        })
+      </OnShow>
+    </Scripts>
     <Layers>
       <Layer level="BACKGROUND">
         <FontString inherits="GameFontNormal" name="Atr_ShpList_Edit_Name" text="EDIT">
@@ -1377,6 +1447,16 @@
             <AbsValue val="32"/>
           </TileSize>
         </Backdrop>
+        <Scripts>
+          <OnShow>
+            self:SetBackdrop({
+              bgFile = "Interface\\CharacterFrame\\UI-Party-Background", 
+              tile = true,
+              tileSize = 32,
+              insets = { left = -20, right = -23, top = -3, bottom = -3, },
+            })
+          </OnShow>
+        </Scripts>
         <Layers>
           <Layer level="ARTWORK">
             <Texture file="Interface\PaperDollInfoFrame\UI-Character-ScrollBar">
@@ -1475,6 +1555,18 @@
         <AbsValue val="32"/>
       </EdgeSize>
     </Backdrop>
+    <Scripts>
+      <OnShow>
+        self:SetBackdrop({
+          bgFile = "Interface\\CharacterFrame\\UI-Party-Background", 
+          edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border", 
+          tile = true,
+          tileSize = 32,
+          edgeSize = 32,
+          insets = { left = 2, right = 0, top = 2, bottom = 2, },
+        })
+      </OnShow>
+    </Scripts>
     <Layers>
       <Layer level="BACKGROUND">
         <FontString inherits="GameFontNormal" spacing="3" text="AUCTIONATOR_SHPLIST_ALREADY_EXIST">

--- a/UI/Frames/ConfirmationDialog.xml
+++ b/UI/Frames/ConfirmationDialog.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/">
-  <Frame name="Atr_Confirm_Frame" toplevel="true" parent="UIParent" enableMouse="true" frameStrata="DIALOG" hidden="true">
+  <Frame name="Atr_Confirm_Frame" toplevel="true" parent="UIParent" enableMouse="true" frameStrata="DIALOG" hidden="true" inherits="BackdropTemplate">
     <Size><AbsDimension x="300" y="150" /></Size>
     <Anchors><Anchor point="TOPLEFT"><Offset><AbsDimension x="290" y="-190"/></Offset></Anchor></Anchors>
 
@@ -10,13 +10,19 @@
     </Backdrop>
 
     <Scripts>
-      <OnLoad>
-        self:SetBackdropColor( 0.3, 0.3, 0.7 )
-      </OnLoad>
       <OnShow>
         if AuctionFrame and AuctionFrame:IsShown() then
           Atr_Mask:Show()
         end
+        self:SetBackdrop({
+          bgFile = "Interface\\MERCHANTFRAME\\UI-BuyBack-TopLeft", 
+          edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border", 
+          tile = true,
+          tileSize = 256,
+          edgeSize = 32,
+          insets = { left = 2, right = 0, top = 2, bottom = 2, },
+        })
+        self:SetBackdropColor( 0.3, 0.3, 0.7 )
       </OnShow>
       <OnHide>
         Atr_Mask:Hide()

--- a/UI/Frames/ErrorMessage.xml
+++ b/UI/Frames/ErrorMessage.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/">
-  <Frame name="Atr_Error_Frame" toplevel="true" parent="UIParent" enableMouse="true" frameStrata="FULLSCREEN_DIALOG" hidden="true">
+  <Frame name="Atr_Error_Frame" toplevel="true" parent="UIParent" enableMouse="true" frameStrata="FULLSCREEN_DIALOG" hidden="true" inherits="BackdropTemplate">
     <Size><AbsDimension x="340" y="160" /></Size>
     <Anchors><Anchor point="TOPLEFT"><Offset><AbsDimension x="290" y="-190"/></Offset></Anchor></Anchors>
 
@@ -11,6 +11,14 @@
 
     <Scripts>
       <OnLoad>
+        self:SetBackdrop({
+          bgFile = "Interface\\MERCHANTFRAME\\UI-BuyBack-TopLeft", 
+          edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border", 
+          tile = true,
+          tileSize = 256,
+          edgeSize = 32,
+          insets = { left = 2, right = 0, top = 2, bottom = 2, },
+        })
         self:SetBackdropColor( 0.3, 0.3, 0.7 )
       </OnLoad>
       <OnShow>

--- a/UI/Frames/FullScan.xml
+++ b/UI/Frames/FullScan.xml
@@ -64,7 +64,7 @@
         <FontStringHeader1 inherits="GameFontNormal"/>
       </SimpleHTML>
 
-      <Frame name="Atr_FullScanResults" hidden="true">
+      <Frame name="Atr_FullScanResults" hidden="true" inherits="BackdropTemplate">
         <Anchors>
           <Anchor point="TOPLEFT"><Offset><AbsDimension y="-195" x="70"/></Offset></Anchor>
           <Anchor point="BOTTOMRIGHT"><Offset><AbsDimension y="30" x="-70"/></Offset></Anchor>
@@ -73,6 +73,15 @@
         <Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border">
           <EdgeSize><AbsValue val="16"/></EdgeSize>
         </Backdrop>
+
+    	<Scripts>
+          <OnShow>
+            self:SetBackdrop({
+              edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border", 
+              edgeSize = 16,
+            })
+          </OnShow>
+        </Scripts>
 
         <Layers>
           <Layer level="ARTWORK">

--- a/UI/Frames/MaskFrame.xml
+++ b/UI/Frames/MaskFrame.xml
@@ -1,17 +1,21 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/">
-  <Frame name="Atr_Mask" toplevel="true" parent="UIParent" enableMouse="true" hidden="true">
+  <Frame name="Atr_Mask" toplevel="true" parent="UIParent" enableMouse="true" hidden="true" inherits="BackdropTemplate">
     <Backdrop bgFile="Interface\Tooltips\UI-Tooltip-Background" tile="true">
       <TileSize><AbsValue val="16"/></TileSize>
     </Backdrop>
 
     <Scripts>
-      <OnLoad>
-        self:SetBackdropColor( 0.2, 0.2, 0.2 )
-      </OnLoad>
       <OnShow>
         self:SetPoint( "TOPLEFT", "AuctionFrame", "TOPLEFT" )
         self:SetPoint( "BOTTOMRIGHT", "AuctionFrame", "BOTTOMRIGHT", 0, -20 )
         self:SetFrameStrata( "HIGH" )
+
+        self:SetBackdrop({
+          bgFile = "Interface\\Tooltips\\UI-Tooltip-Background", 
+          tile = true,
+          tileSize = 16,
+        })
+        self:SetBackdropColor( 0.2, 0.2, 0.2 )
       </OnShow>
     </Scripts>
   </Frame>

--- a/UI/Templates/Dialogs/Default.xml
+++ b/UI/Templates/Dialogs/Default.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/">
-  <Frame name="AuctionatorDialog" virtual="true">
+  <Frame name="AuctionatorDialog" virtual="true" inherits="BackdropTemplate">
     <Backdrop bgFile="Interface\CharacterFrame\UI-Party-Background" edgeFile="Interface\DialogFrame\UI-DialogBox-Border" tile="true">
       <BackgroundInsets><AbsInset left="11" right="12" top="12" bottom="11"/></BackgroundInsets>
       <TileSize><AbsValue val="32"/></TileSize>
@@ -8,6 +8,14 @@
 
     <Scripts>
       <OnShow>
+        self:SetBackdrop({
+          bgFile = "Interface\\CharacterFrame\\UI-Party-Background",
+          edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border", 
+          tile = true,
+          tileSize = 32,
+          edgeSize = 32,
+          insets = { left = 11, right = 12, top = 12, bottom = 11, },
+        })
         if (AuctionFrame and AuctionFrame:IsShown()) then
           self:ClearAllPoints ();
           self:SetPoint ("CENTER", "AuctionFrame", "CENTER");

--- a/UI/Templates/Frames/Sell.xml
+++ b/UI/Templates/Frames/Sell.xml
@@ -196,13 +196,23 @@
         </Scripts>
       </ScrollFrame>
 
-      <Frame name="Atr_Hlist" hidden="true">
+      <Frame name="Atr_Hlist" hidden="true" inherits="BackdropTemplate">
         <Size><AbsDimension x="170" y="335"/></Size>
         <Anchors><Anchor point="TOPLEFT"><Offset><AbsDimension x="-193" y="-75"/></Offset></Anchor></Anchors>
         <Backdrop bgFile="Interface\CharacterFrame\UI-Party-Background" tile="true">
           <BackgroundInsets><AbsInset left="0" right="-24" top="0" bottom="0"/></BackgroundInsets>
           <TileSize><AbsValue val="256"/></TileSize>
         </Backdrop>
+        <Scripts>
+          <OnShow>
+            self:SetBackdrop({
+              bgFile = "Interface\\CharacterFrame\\UI-Party-Background", 
+              tile = true,
+              tileSize = 256,
+              insets = { left = 0, right = -24, top = 0, bottom = 0, },
+            })
+          </OnShow>
+        </Scripts>
         <Layers>
           <Layer level="ARTWORK">
             <Texture file="Interface\Tooltips\UI-Tooltip-Border">
@@ -624,7 +634,7 @@
         </Scripts>
         </Frame>
 
-      <Frame name="Atr_Hilite1" hidden="true">
+      <Frame name="Atr_Hilite1" hidden="true" inherits="BackdropTemplate">
         <Size><AbsDimension y="111" /></Size>
         <Anchors>
           <Anchor point="TOPLEFT"><Offset><AbsDimension x="5" y="-72"/></Offset></Anchor>
@@ -636,6 +646,14 @@
             <AbsValue val="16"/>
           </EdgeSize>
         </Backdrop>
+        <Scripts>
+          <OnShow>
+            self:SetBackdrop({
+              edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border", 
+              edgeSize = 16,
+            })
+          </OnShow>
+        </Scripts>
       </Frame>
 
       <Button>


### PR DESCRIPTION
Fixes issues with TBC dropping support for the XML key <Backdrop>. I left the XML keys for <Backdrop> as they were, but added new scripts to each frame that needs them for setting the Backdrop information. I also added `inherits="BackdropTemplate"` to any Frame which requires them since TBC now requires this.